### PR TITLE
Promote to prod environment

### DIFF
--- a/components/nodejs-mcpyhxhb/overlays/prod/deployment-patch.yaml
+++ b/components/nodejs-mcpyhxhb/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/dance-bootstrap-app:latest
+      - image: artifactory-docker-artifactory-jcr.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/nodejs-mcpyhxhb:c803d9d8f2702e043b7343826c3dff1bc8f27c72@sha256:2f5b64d5987a5e1850b58898f1fd8a510318bb19673d7dccff89ca8c71356ca0
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/nodejs-mcpyhxhb:c803d9d8f2702e043b7343826c3dff1bc8f27c72@sha256:2f5b64d5987a5e1850b58898f1fd8a510318bb19673d7dccff89ca8c71356ca0